### PR TITLE
Added error handling for webgl failure edge case

### DIFF
--- a/src/components/underlay.tsx
+++ b/src/components/underlay.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Stats } from "@react-three/drei"
 import { Canvas } from "@react-three/fiber"
 import * as THREE from "three"
@@ -14,6 +14,22 @@ export const Underlay: React.FC<{
   mode?: "ring" | "model"
 }> = ({ mode = "model" }) => {
   const pointRef = useRef<THREE.Mesh>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const gl = useRef<WebGLRenderingContext>()
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    try{
+      gl.current = new THREE.WebGLRenderer({ canvas: canvasRef.current!,
+        antialias: false,
+        stencil: false,
+        depth: false,
+        alpha: true,
+      }).getContext();
+    } catch (e) {
+      setError(e as Error)
+    }
+  }, [canvasRef])
 
   return (
     <div
@@ -26,9 +42,11 @@ export const Underlay: React.FC<{
         zIndex: 0,
       }}
     >
+      {!error && (
       <Canvas
+        ref={canvasRef}
         shadows={false}
-        gl={{ alpha: true, stencil: false, depth: false, antialias: false }}
+        gl={gl.current}
         camera={{ position: [0, 0, 18], fov: 2, near: 1, far: 100 }}
       >
         <PCDModel
@@ -42,7 +60,8 @@ export const Underlay: React.FC<{
           // rotation={new THREE.Euler(-0.2, 0, 0)}
         />
         {isDev && <Stats />}
-      </Canvas>
+        </Canvas>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Adds error handling if the three.js WebGL context fails.
One of the ways this can happen is if browser acceleration is turned off.

To address this edge-case I disable the three.js Canvas if there's an error.

Before:
<img width="1700" alt="Screenshot 2024-10-22 at 6 03 10 pm" src="https://github.com/user-attachments/assets/03535770-499b-4888-a1b0-562248e41f46">

After:
<img width="1684" alt="Screenshot 2024-10-22 at 6 00 03 pm" src="https://github.com/user-attachments/assets/e4728463-6398-42df-a289-f3389138eced"> 